### PR TITLE
Patched highlightjs -> 10.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.2
+
+- Patched highlight.js to 10.4.1
+
 ## v1.0.1
 
 - Removed the examples folder, as it was misleading and not used/maintained

--- a/package-lock.json
+++ b/package-lock.json
@@ -1467,9 +1467,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.0.tgz",
-      "integrity": "sha512-EfrUGcQ63oLJbj0J0RI9ebX6TAITbsDBLbsjr881L/X5fMO9+oadKzEF21C7R3ULKG6Gv3uoab2HiqVJa/4+oA=="
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
+      "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg=="
     },
     "hosted-git-info": {
       "version": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/dhershman1/pinet#readme",
   "dependencies": {
     "fs-extra": "9.0.1",
-    "highlight.js": "10.4.0",
+    "highlight.js": "10.4.1",
     "kyanite": "1.4.2",
     "marked": "1.2.5"
   },

--- a/tmpl/layout.js
+++ b/tmpl/layout.js
@@ -39,7 +39,7 @@ function layout (opts) {
           text('Powered by '),
           a({ href: 'https://github.com/dhershman1/pinet' }, [text('Pinet')])
         ]),
-        compile('script', { src: 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.4.0/highlight.min.js' }, []),
+        compile('script', { src: 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.4.1/highlight.min.js' }, []),
         compile('script', { src: 'static/js/search.js' }, [])
       ]))
     ]), '<!DOCTYPE html>')


### PR DESCRIPTION

- Moves highlight.js to `v10.4.1` per dependabots recommendation